### PR TITLE
chore(extensions): :wrench: add VSCode extensions list for aheitz

### DIFF
--- a/.ext/aheitz.txt
+++ b/.ext/aheitz.txt
@@ -1,0 +1,110 @@
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    aheitz.txt                                         :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: aheitz <aheitz@student.42.fr>              +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2025/06/28 08:51:07 by aheitz            #+#    #+#              #
+#    Updated: 2025/06/28 08:51:08 by aheitz           ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
+
+// Just a file containing @aheitz's active extensions.
+// TODO: Delete from final version.
+
+aaron-bond.better-comments@3.0.2
+akamud.vscode-theme-onedark@2.3.0
+alefragnani.bookmarks@13.5.0
+alefragnani.project-manager@12.8.0
+asciidoctor.asciidoctor-vscode@3.4.2
+bierner.markdown-checkbox@0.4.0
+bierner.markdown-mermaid@1.28.0
+bmewburn.vscode-intelephense-client@1.14.4
+bradlc.vscode-tailwindcss@0.14.23
+britesnow.vscode-toggle-quotes@0.3.6
+caarlos0.language-prometheus@0.1.2
+chakrounanas.turbo-console-log@3.1.0
+christian-kohler.npm-intellisense@1.4.5
+christian-kohler.path-intellisense@2.10.0
+cschlosser.doxdocgen@1.4.0
+davidanson.vscode-markdownlint@0.60.0
+dbaeumer.vscode-eslint@3.0.15
+dokca.42-ft-count-line@0.5.0
+donjayamanne.githistory@0.6.20
+dsznajder.es7-react-js-snippets@4.4.3
+durzn.brackethighlighter@3.0.3
+eamodio.gitlens@17.2.1
+ecmel.vscode-html-css@2.0.13
+editorconfig.editorconfig@0.17.4
+erikphansen.vscode-toggle-column-selection@1.0.6
+esbenp.prettier-vscode@11.0.0
+formulahendry.auto-close-tag@0.5.15
+formulahendry.auto-rename-tag@0.1.10
+formulahendry.code-runner@0.12.2
+github.codespaces@1.17.3
+github.copilot@1.338.1648
+github.copilot-chat@0.27.3
+github.vscode-github-actions@0.27.2
+github.vscode-pull-request-github@0.113.2025062404
+graphql.vscode-graphql@0.13.2
+graphql.vscode-graphql-syntax@1.3.8
+gruntfuggly.todo-tree@0.0.226
+heybourn.headwind@1.7.0
+humao.rest-client@0.25.1
+ibm.output-colorizer@0.1.2
+irongeek.vscode-env@0.1.0
+johnpapa.vscode-peacock@4.2.2
+k--kato.docomment@1.0.0
+kube.42header@0.42.9
+mbmgfnbk.atom-one-dark-pro-ui@0.0.2
+meganrogge.template-string-converter@0.6.1
+mhutchie.git-graph@1.30.0
+mikestead.dotenv@1.0.1
+moshfeu.compare-folders@0.25.1
+mrmlnc.vscode-duplicate@1.2.1
+ms-azuretools.vscode-containers@2.0.3
+ms-azuretools.vscode-docker@2.0.0
+ms-playwright.playwright@1.1.15
+ms-vscode-remote.remote-containers@0.417.0
+ms-vscode-remote.remote-ssh@0.120.0
+ms-vscode-remote.remote-ssh-edit@0.87.0
+ms-vscode-remote.remote-wsl@0.99.0
+ms-vscode-remote.vscode-remote-extensionpack@0.26.0
+ms-vscode.live-server@0.4.15
+ms-vscode.makefile-tools@0.13.6
+ms-vscode.remote-explorer@0.5.0
+ms-vscode.remote-server@1.5.2
+ms-vscode.vscode-typescript-next@5.9.20250627
+ms-vsliveshare.vsliveshare@1.0.5948
+naumovs.color-highlight@2.8.0
+nicoespeon.abracadabra@9.8.0
+oderwat.indent-rainbow@8.3.1
+orta.vscode-jest@6.4.3
+pkief.material-icon-theme@5.24.0
+pnp.polacode@0.3.4
+qwtel.sqlite-viewer@25.6.0
+rangav.vscode-thunder-client@2.35.2
+redhat.vscode-xml@0.29.2025051008
+redhat.vscode-yaml@1.18.0
+ritwickdey.liveserver@5.7.9
+ryanluker.vscode-coverage-gutters@2.13.0
+shardulm94.trailing-spaces@0.4.1
+shd101wyy.markdown-preview-enhanced@0.8.18
+sleistner.vscode-fileutils@3.10.3
+streetsidesoftware.code-spell-checker@4.0.47
+streetsidesoftware.code-spell-checker-french@0.4.3
+tamasfe.even-better-toml@0.21.2
+timonwong.shellcheck@0.37.7
+tomoki1207.pdf@1.2.2
+usernamehw.errorlens@3.26.0
+usernamehw.indent-one-space@1.0.0
+visualstudioexptteam.intellicode-api-usage-examples@0.2.9
+visualstudioexptteam.vscodeintellicode@1.3.2
+vivaxy.vscode-conventional-commits@1.26.0
+vscode-icons-team.vscode-icons@12.13.0
+wayou.vscode-todo-highlight@1.0.5
+william-voyek.vscode-nginx@0.7.2
+wix.vscode-import-cost@3.3.0
+yoavbls.pretty-ts-errors@0.6.1
+yzhang.markdown-all-in-one@3.6.3


### PR DESCRIPTION
- Includes currently active extensions in `.ext/aheitz.txt` for local development reference.
- This file helps share tooling setup and may be removed or centralized later.